### PR TITLE
Argument: --path filtering - refs #35

### DIFF
--- a/chglog.go
+++ b/chglog.go
@@ -33,6 +33,7 @@ type Options struct {
 	RevertPattern        string              // A regular expression to use for parsing the revert commit
 	RevertPatternMaps    []string            // Similar to `HeaderPatternMaps`
 	NoteKeywords         []string            // Keyword list to find `Note`. A semicolon is a separator, like `<keyword>:` (e.g. `BREAKING CHANGE`)
+	Paths                []string            // Path filter
 }
 
 // Info is metadata related to CHANGELOG

--- a/cmd/git-chglog/config.go
+++ b/cmd/git-chglog/config.go
@@ -259,6 +259,7 @@ func (config *Config) Convert(ctx *CLIContext) *chglog.Config {
 		Options: &chglog.Options{
 			NextTag:              ctx.NextTag,
 			TagFilterPattern:     ctx.TagFilterPattern,
+			Paths:                ctx.Paths,
 			CommitFilters:        opts.Commits.Filters,
 			CommitSortBy:         opts.Commits.SortBy,
 			CommitGroupBy:        opts.CommitGroups.GroupBy,

--- a/cmd/git-chglog/context.go
+++ b/cmd/git-chglog/context.go
@@ -17,6 +17,7 @@ type CLIContext struct {
 	Query            string
 	NextTag          string
 	TagFilterPattern string
+	Paths            []string
 }
 
 // InitContext ...

--- a/cmd/git-chglog/main.go
+++ b/cmd/git-chglog/main.go
@@ -76,6 +76,12 @@ func CreateApp(actionFunc cli.ActionFunc) *cli.App {
 			Usage: "generate the git-chglog configuration file in interactive",
 		},
 
+		// path
+		cli.StringSliceFlag{
+			Name:  "path",
+			Usage: "Paths to include in changelog",
+		},
+
 		// config
 		cli.StringFlag{
 			Name:  "config, c",
@@ -116,8 +122,8 @@ func CreateApp(actionFunc cli.ActionFunc) *cli.App {
 
 		// tag-filter-pattern
 		cli.StringFlag{
-			Name:   "tag-filter-pattern, p",
-			Usage:  "Regular expression of tag filter. Is specified, only matched tags will be picked",
+			Name:  "tag-filter-pattern, p",
+			Usage: "Regular expression of tag filter. Is specified, only matched tags will be picked",
 		},
 
 		// help & version
@@ -172,7 +178,9 @@ func AppAction(c *cli.Context) error {
 			NoEmoji:    c.Bool("no-emoji"),
 			Query:      c.Args().First(),
 			NextTag:    c.String("next-tag"),
+
 			TagFilterPattern: c.String("tag-filter-pattern"),
+			Paths:            c.StringSlice("path"),
 		},
 		fs,
 		NewConfigLoader(),

--- a/commit_parser.go
+++ b/commit_parser.go
@@ -79,12 +79,20 @@ func newCommitParser(client gitcmd.Client, config *Config) *commitParser {
 }
 
 func (p *commitParser) Parse(rev string) ([]*Commit, error) {
-	out, err := p.client.Exec(
-		"log",
+	paths := p.config.Options.Paths
+
+	args := []string{
 		rev,
 		"--no-decorate",
-		"--pretty="+logFormat,
-	)
+		"--pretty=" + logFormat,
+	}
+
+	if len(paths) > 0 {
+		args = append(args, "--")
+		args = append(args, paths...)
+	}
+
+	out, err := p.client.Exec("log", args...)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!-- Thank you for your contribution to git-chglog! Please replace {Please write here} with your description -->


## What does this do / why do we need it?


This handles cases where you have a monorepo and want to generate changelogs on a per project basis - but they are all in a single repo.

## How this PR fixes the problem?

Adds a new options --path
That can be used to only pick commits that apply to a part of the repo file system

## What should your reviewer look out for in this PR?




## Check lists

* [ ] Test passed
* [ ] Coding style (indentation, etc)


## Additional Comments (if any)

fixed #35


## Which issue(s) does this PR fix?

<!--
fixes #
fixes #
-->
